### PR TITLE
Only load Admin scripts on the wpquerypush page

### DIFF
--- a/wp-query-push.php
+++ b/wp-query-push.php
@@ -211,7 +211,7 @@ function enqueue_admin_scripts()
         sanitize_text_field( wp_unslash( $_GET['page'] ) ) !== 'wpquerypush'
     ) {
     */
-    if ( is_admin() ) {
+    if ( is_admin() && ( isset( $_GET['page'] ) && $_GET['page'] === 'wpquerypush' ) ) {
         $metadata = require_once plugin_dir_path(__FILE__) . 'build/index.asset.php';
         wp_enqueue_script(
             'wpquerypush',


### PR DESCRIPTION
Fixes css applying to other pages on the admin: 
![image](https://github.com/zdmc23/wp-query-push/assets/24901539/ab27bcad-2f7c-420c-adb4-4cc90a1d5465)

Should look like:
![image](https://github.com/zdmc23/wp-query-push/assets/24901539/1b9ed72e-1507-4bca-a1bf-5c9c5585ebc4)
