### PR TITLE
Made wp-json calls compatible with WP instances installed in subdirec…

### DIFF
--- a/src/hooks/use-api-hints.js
+++ b/src/hooks/use-api-hints.js
@@ -1,5 +1,5 @@
 import useSWR from "swr";
 import { fetcher } from "@/helpers";
 
-const useApiHints = () => useSWR("/wp-json/wp-query-push/v1/get-api-hints", fetcher);
+const useApiHints = () => useSWR("../wp-json/wp-query-push/v1/get-api-hints", fetcher);
 export default useApiHints;

--- a/src/hooks/use-api-hints.js
+++ b/src/hooks/use-api-hints.js
@@ -1,5 +1,5 @@
 import useSWR from "swr";
 import { fetcher } from "@/helpers";
 
-const useApiHints = () => useSWR("../wp-json/wp-query-push/v1/get-api-hints", fetcher);
+const useApiHints = () => useSWR("../wp-json/wp-query-push/v1/get-api-hints", fetcher); // Reason for double dots: https://github.com/zdmc23/wp-query-push/pull/9
 export default useApiHints;

--- a/src/hooks/use-connections.js
+++ b/src/hooks/use-connections.js
@@ -1,5 +1,5 @@
 import useSWR from "swr";
 import { fetcher } from "@/helpers";
 
-const useConnections = () => useSWR("/wp-json/wp-query-push/v1/connections", fetcher);
+const useConnections = () => useSWR("../wp-json/wp-query-push/v1/connections", fetcher);
 export default useConnections;

--- a/src/hooks/use-connections.js
+++ b/src/hooks/use-connections.js
@@ -1,5 +1,5 @@
 import useSWR from "swr";
 import { fetcher } from "@/helpers";
 
-const useConnections = () => useSWR("../wp-json/wp-query-push/v1/connections", fetcher);
+const useConnections = () => useSWR("../wp-json/wp-query-push/v1/connections", fetcher); // Reason for double dots: https://github.com/zdmc23/wp-query-push/pull/9
 export default useConnections;

--- a/src/hooks/use-intervals.js
+++ b/src/hooks/use-intervals.js
@@ -1,5 +1,5 @@
 import useSWR from "swr";
 import { fetcher } from "@/helpers";
 
-const useIntervals = () => useSWR("../wp-json/wp-query-push/v1/intervals", fetcher);
+const useIntervals = () => useSWR("../wp-json/wp-query-push/v1/intervals", fetcher); // Reason for double dots: https://github.com/zdmc23/wp-query-push/pull/9
 export default useIntervals;

--- a/src/hooks/use-intervals.js
+++ b/src/hooks/use-intervals.js
@@ -1,5 +1,5 @@
 import useSWR from "swr";
 import { fetcher } from "@/helpers";
 
-const useIntervals = () => useSWR("/wp-json/wp-query-push/v1/intervals", fetcher);
+const useIntervals = () => useSWR("../wp-json/wp-query-push/v1/intervals", fetcher);
 export default useIntervals;

--- a/src/hooks/use-logs.js
+++ b/src/hooks/use-logs.js
@@ -1,5 +1,5 @@
 import useSWR from "swr";
 import { fetcher } from "@/helpers";
 
-const useLogs = () => useSWR("/wp-json/wp-query-push/v1/logs", fetcher);
+const useLogs = () => useSWR("../wp-json/wp-query-push/v1/logs", fetcher);
 export default useLogs;

--- a/src/hooks/use-logs.js
+++ b/src/hooks/use-logs.js
@@ -1,5 +1,5 @@
 import useSWR from "swr";
 import { fetcher } from "@/helpers";
 
-const useLogs = () => useSWR("../wp-json/wp-query-push/v1/logs", fetcher);
+const useLogs = () => useSWR("../wp-json/wp-query-push/v1/logs", fetcher); // Reason for double dots: https://github.com/zdmc23/wp-query-push/pull/9
 export default useLogs;

--- a/src/hooks/use-tables.js
+++ b/src/hooks/use-tables.js
@@ -1,5 +1,5 @@
 import useSWR from "swr";
 import { fetcher } from "@/helpers";
 
-const useTables = () => useSWR("../wp-json/wp-query-push/v1/tables", fetcher);
+const useTables = () => useSWR("../wp-json/wp-query-push/v1/tables", fetcher); // Reason for double dots: https://github.com/zdmc23/wp-query-push/pull/9
 export default useTables;

--- a/src/hooks/use-tables.js
+++ b/src/hooks/use-tables.js
@@ -1,5 +1,5 @@
 import useSWR from "swr";
 import { fetcher } from "@/helpers";
 
-const useTables = () => useSWR("/wp-json/wp-query-push/v1/tables", fetcher);
+const useTables = () => useSWR("../wp-json/wp-query-push/v1/tables", fetcher);
 export default useTables;


### PR DESCRIPTION
# Compatibility Enhancement for WordPress Instances Installed in Subdirectories
## Overview

This pull request fixes a problem in WordPress when it's installed in subdirectories. Previously, links didn't work correctly in subdirectory installations. We've made a simple change to make sure links work properly in those situations.

## Problem

Before, links were broken in subdirectory WordPress installations. For example, if your site was at https://example.com/wp/, links didn't work as expected. This fix ensures links are correct, like https://example.com/wp/wp-json/my-api-route.

## Solution

We've made a small change to links. Instead of /wp-json/my-api-route, they now look like ../wp-json/my-api-route. This only affects certain pages, so it won't break anything else. This fix makes links work for all WordPress installations.